### PR TITLE
fix indent guide colors

### DIFF
--- a/one-dark-pro.json
+++ b/one-dark-pro.json
@@ -514,6 +514,18 @@
       "bgColor": "#515a6b", 
       "layer": 300
     },
+    "editor.indent.guide": {
+      "fgColor": "Gray 70",
+      "decoration": {
+        "style": "SOLID"
+      }
+    },
+    "editor.indent.guide.current": {
+      "fgColor": "Gray 100",
+      "decoration": {
+        "style": "SOLID"
+      }
+    },
     "comment": {
       "fgColor": "Gray 90",
       "layer": 5,


### PR DESCRIPTION

It looks like the default colors for the indent guides is blue which does not fit the one dark color scheme. I changed these colors to be gray so that they better fit the color scheme.

Initial colors:

![image](https://github.com/sectasy0/fleet_one_dark/assets/45863534/07d4e191-fdb3-42e7-ad95-bf825e3f7262)

post changes:

![image](https://github.com/sectasy0/fleet_one_dark/assets/45863534/bd1a3f97-4e2f-41f6-9a08-feb437e3c42c)
